### PR TITLE
chore: changing default nginx port

### DIFF
--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -6,6 +6,6 @@ spec:
   selector:
     app: nginx
   ports:
-  - port: 80
+  - port: 8080
     targetPort: 80
   type: ClusterIP


### PR DESCRIPTION
Due a security feedback we must replace the default Nginx port.